### PR TITLE
Upstream Update

### DIFF
--- a/Waterfall-Proxy-Patches/0004-Make-PlayerHandshakeEvent-cancellable.patch
+++ b/Waterfall-Proxy-Patches/0004-Make-PlayerHandshakeEvent-cancellable.patch
@@ -1,4 +1,4 @@
-From 9a7e67bef272c161ca784e54492e95e50140f384 Mon Sep 17 00:00:00 2001
+From 52968afed745e49517f2eefa5aae6be6a36aa714 Mon Sep 17 00:00:00 2001
 From: foss-mc <69294560+foss-mc@users.noreply.github.com>
 Date: Wed, 16 Dec 2020 17:57:23 +0800
 Subject: [PATCH] Make PlayerHandshakeEvent cancellable
@@ -35,10 +35,10 @@ index 2f7b38d9..e29b0ed3 100644
      /**
       * Connection attempting to login.
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index fe6ff143..c2ec12b4 100644
+index 3b82219d..5407c20a 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -341,7 +341,11 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -338,7 +338,11 @@ public class InitialHandler extends PacketHandler implements PendingConnection
  
          this.virtualHost = InetSocketAddress.createUnresolved( handshake.getHost(), handshake.getPort() );
  

--- a/Waterfall-Proxy-Patches/0010-Close-connections-Don-t-flush-if-not-necessary.patch
+++ b/Waterfall-Proxy-Patches/0010-Close-connections-Don-t-flush-if-not-necessary.patch
@@ -1,14 +1,14 @@
-From e2a93fffc50d08cc1d1a97d5c8b713add74feb69 Mon Sep 17 00:00:00 2001
+From 9c750441ab21769e9fc5ee37e7642a5de7f2dcd3 Mon Sep 17 00:00:00 2001
 From: foss-mc <69294560+foss-mc@users.noreply.github.com>
 Date: Wed, 16 Dec 2020 18:06:17 +0800
 Subject: [PATCH] Close connections & Don't flush if not necessary
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index c2ec12b4..1be9ae77 100644
+index 5407c20a..e9937428 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -197,6 +197,13 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -194,6 +194,13 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                  }
  
                  ServerPing legacy = result.getResponse();
@@ -22,7 +22,7 @@ index c2ec12b4..1be9ae77 100644
                  String kickMessage;
  
                  if ( v1_5 )
-@@ -267,6 +274,16 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -264,6 +271,16 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                          {
                              bungee.getConnectionThrottle().unthrottle( getSocketAddress() );
                          }
@@ -39,7 +39,7 @@ index c2ec12b4..1be9ae77 100644
                          // Travertine start
                          if ( ProtocolConstants.isBeforeOrEq( handshake.getProtocolVersion() , ProtocolConstants.MINECRAFT_1_8 ) )
                          {
-@@ -307,11 +324,11 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -304,11 +321,11 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      @Override
      public void handle(PingPacket ping) throws Exception
      {
@@ -55,7 +55,7 @@ index c2ec12b4..1be9ae77 100644
      }
  
      @Override
-@@ -619,7 +636,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -624,7 +641,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      {
          if ( canSendKickMessage() )
          {

--- a/Waterfall-Proxy-Patches/0012-Packet-Checks.patch
+++ b/Waterfall-Proxy-Patches/0012-Packet-Checks.patch
@@ -1,14 +1,14 @@
-From 7ff984d41446f889b790be1376acae78cddc2fe8 Mon Sep 17 00:00:00 2001
+From 8ead27c615cb3fcc53cabf3399c65347d4fd6994 Mon Sep 17 00:00:00 2001
 From: foss-mc <69294560+foss-mc@users.noreply.github.com>
 Date: Wed, 16 Dec 2020 18:10:30 +0800
 Subject: [PATCH] Packet Checks
 
 
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
-index ec932e92..f1f34626 100644
+index 2caadfed..d4729244 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
-@@ -39,6 +39,19 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
+@@ -38,6 +38,19 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
          }
  
          Protocol.DirectionData prot = ( server ) ? protocol.TO_SERVER : protocol.TO_CLIENT;

--- a/Waterfall-Proxy-Patches/0016-Change-state-to-encrypt-only-if-onlineMode-is-true.patch
+++ b/Waterfall-Proxy-Patches/0016-Change-state-to-encrypt-only-if-onlineMode-is-true.patch
@@ -1,14 +1,14 @@
-From 1fa924e0e980d172556ff43ee97caee5211c53a0 Mon Sep 17 00:00:00 2001
+From 501c340474b980137994535738a1ac736b6d0e6a Mon Sep 17 00:00:00 2001
 From: foss-mc <69294560+foss-mc@users.noreply.github.com>
 Date: Wed, 16 Dec 2020 18:25:03 +0800
 Subject: [PATCH] Change state to encrypt only if onlineMode is true
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 1be9ae77..93486904 100644
+index e9937428..037a305b 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -452,11 +452,12 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -449,11 +449,12 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                  if ( onlineMode )
                  {
                      unsafe().sendPacket( request = EncryptionUtil.encryptRequest() );

--- a/Waterfall-Proxy-Patches/0017-Don-t-allow-name-containing-dot.patch
+++ b/Waterfall-Proxy-Patches/0017-Don-t-allow-name-containing-dot.patch
@@ -1,14 +1,14 @@
-From 69632ee3a5f3963b39c933c2dba4d0c3ecf05f6c Mon Sep 17 00:00:00 2001
+From 355853706ca50aba3dc231b6adee5f5e8bd58548 Mon Sep 17 00:00:00 2001
 From: foss-mc <69294560+foss-mc@users.noreply.github.com>
 Date: Wed, 16 Dec 2020 18:25:51 +0800
 Subject: [PATCH] Don't allow name containing dot
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 93486904..1f5492fb 100644
+index 037a305b..c6dfa00f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -407,13 +407,16 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -404,13 +404,16 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          Preconditions.checkState( thisState == State.USERNAME, "Not expecting USERNAME" );
          this.loginRequest = loginRequest;
  

--- a/Waterfall-Proxy-Patches/0019-Allow-custom-uuids-even-if-onlineMode-is-true.patch
+++ b/Waterfall-Proxy-Patches/0019-Allow-custom-uuids-even-if-onlineMode-is-true.patch
@@ -1,14 +1,14 @@
-From ce563b65a254311d942f69311fa5e675cbedd48e Mon Sep 17 00:00:00 2001
+From 461651e8a304ff9f57adac8d9c975b2a7e6ce1ea Mon Sep 17 00:00:00 2001
 From: foss-mc <69294560+foss-mc@users.noreply.github.com>
 Date: Wed, 16 Dec 2020 18:35:33 +0800
 Subject: [PATCH] Allow custom uuids even if onlineMode is true
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 1f5492fb..b71d25dc 100644
+index c6dfa00f..3c67494f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -698,7 +698,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -703,7 +703,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      public void setUniqueId(UUID uuid)
      {
          Preconditions.checkState( thisState == State.USERNAME, "Can only set uuid while state is username" );

--- a/Waterfall-Proxy-Patches/0020-Finish-early-to-avoid-multiple-incoming-packets.patch
+++ b/Waterfall-Proxy-Patches/0020-Finish-early-to-avoid-multiple-incoming-packets.patch
@@ -1,23 +1,23 @@
-From 68c2b0ea3b16f7b571ff8c576f54042f4402e251 Mon Sep 17 00:00:00 2001
+From e57213dfb0ed9e6ebb122cb95d08a2e7592c4c60 Mon Sep 17 00:00:00 2001
 From: foss-mc <69294560+foss-mc@users.noreply.github.com>
 Date: Wed, 16 Dec 2020 18:36:08 +0800
 Subject: [PATCH] Finish early to avoid multiple incoming packets
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index b71d25dc..61f80012 100644
+index 3c67494f..f7ed1f46 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -472,6 +472,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
-     public void handle(final EncryptionResponse encryptResponse) throws Exception
+@@ -470,6 +470,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      {
          Preconditions.checkState( thisState == State.ENCRYPT, "Not expecting ENCRYPT" );
-
+ 
 +        // FlameCord - Finish here to avoid multiple incoming packets
 +        thisState = State.FINISHED;
          SecretKey sharedKey = EncryptionUtil.getSecret( encryptResponse, request );
          // Waterfall start
-@@ -524,6 +526,9 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+         if (sharedKey instanceof SecretKeySpec) {
+@@ -529,6 +531,9 @@ public class InitialHandler extends PacketHandler implements PendingConnection
  
      private void finish()
      {
@@ -27,7 +27,7 @@ index b71d25dc..61f80012 100644
          if ( isOnlineMode() )
          {
              // Check for multiple connections
-@@ -605,8 +610,6 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -610,8 +615,6 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                              }
  
                              userCon.connect( server, null, true, ServerConnectEvent.Reason.JOIN_PROXY );

--- a/Waterfall-Proxy-Patches/0022-Don-t-declare-uuid-unless-it-s-null.patch
+++ b/Waterfall-Proxy-Patches/0022-Don-t-declare-uuid-unless-it-s-null.patch
@@ -1,14 +1,14 @@
-From 67efa4ede50e4b1fbf0d5dc8528b8543424a289b Mon Sep 17 00:00:00 2001
+From 1d113c7643f8d333cd70d8e6ddd64e78c1ab73be Mon Sep 17 00:00:00 2001
 From: foss-mc <69294560+foss-mc@users.noreply.github.com>
 Date: Wed, 16 Dec 2020 18:43:17 +0800
 Subject: [PATCH] Don't declare uuid unless it's null
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 61f80012..502e0ae1 100644
+index f7ed1f46..e7542b1c 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -508,7 +508,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -513,7 +513,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                      {
                          loginProfile = obj;
                          name = obj.getName();

--- a/Waterfall-Proxy-Patches/0023-FlameCord-General-Patch.patch
+++ b/Waterfall-Proxy-Patches/0023-FlameCord-General-Patch.patch
@@ -1,4 +1,4 @@
-From 83dd5ab49ce6fcada7fb212a33db9c674fd66e63 Mon Sep 17 00:00:00 2001
+From ed57b22b9bae1cabd74f9dd91ebe83389d6223ee Mon Sep 17 00:00:00 2001
 From: Juan Cruz Linsalata <LinsaFTW@users.noreply.github.com>
 Date: Mon, 12 Oct 2020 15:40:53 -0300
 Subject: [PATCH] FlameCord General Patch
@@ -563,7 +563,7 @@ index 00000000..8a474758
 +}
 \ No newline at end of file
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
-index f1f34626..1ea85e18 100644
+index d4729244..dd089abd 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
 @@ -1,5 +1,6 @@
@@ -573,7 +573,7 @@ index f1f34626..1ea85e18 100644
  import io.netty.buffer.ByteBuf;
  import io.netty.buffer.ByteBufUtil;
  import io.netty.channel.ChannelHandlerContext;
-@@ -92,7 +93,14 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
+@@ -102,7 +103,14 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
              } else {
                  packetTypeStr = "unknown";
              }
@@ -889,19 +889,19 @@ index 159119c1..7c4c8f8a 100644
          b.connect().addListener( listener );
      }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 502e0ae1..138dffa0 100644
+index e7542b1c..47a9c74d 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -19,6 +19,8 @@ import com.google.gson.Gson;
+@@ -16,6 +16,8 @@ import java.util.logging.Level;
+ import javax.crypto.SecretKey;
+ import javax.crypto.spec.SecretKeySpec;
  
- import com.google.gson.JsonElement;
- import com.google.gson.JsonObject;
-+
 +import dev._2lstudios.flamecord.FlameCord;
++
  import lombok.Getter;
  import lombok.RequiredArgsConstructor;
  import net.md_5.bungee.BungeeCord;
-@@ -52,6 +54,7 @@ import net.md_5.bungee.netty.PacketHandler;
+@@ -49,6 +51,7 @@ import net.md_5.bungee.netty.PacketHandler;
  import net.md_5.bungee.netty.PipelineUtils;
  import net.md_5.bungee.netty.cipher.CipherDecoder;
  import net.md_5.bungee.netty.cipher.CipherEncoder;
@@ -909,7 +909,7 @@ index 502e0ae1..138dffa0 100644
  import net.md_5.bungee.protocol.DefinedPacket;
  import net.md_5.bungee.protocol.PacketWrapper;
  import net.md_5.bungee.protocol.Protocol;
-@@ -155,7 +158,13 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -152,7 +155,13 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      {
          if ( packet.packet == null )
          {
@@ -924,7 +924,7 @@ index 502e0ae1..138dffa0 100644
          }
      }
  
-@@ -368,7 +377,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -365,7 +374,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          {
              case 1:
                  // Ping
@@ -934,7 +934,7 @@ index 502e0ae1..138dffa0 100644
                  {
                      bungee.getLogger().log( Level.INFO, "{0} has pinged", this );
                  }
-@@ -377,7 +387,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -374,7 +384,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                  break;
              case 2:
                  // Login


### PR DESCRIPTION
https://github.com/2LStudios-MC/FlameCord/commit/8c3c544142a96df4a269b998870622fef61538f1#commitcomment-47491817

@LinsaFTW
There is no need to manually edit patches.

1. Run `./travertine p` to get a clean `Travertine-Proxy` directory
2. Update Travertine Files
3. Run `./travertine p`
 ```
Applying: FlameCord General Patch
Using index info to reconstruct a base tree...
M	protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
M	proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
.git/rebase-apply/patch:728: trailing whitespace.
        
warning: 1 line adds whitespace errors.
Falling back to patching base and 3-way merge...
Auto-merging proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
CONFLICT (content): Merge conflict in proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
Auto-merging protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
error: Failed to merge in the changes.
Patch failed at 0023 FlameCord General Patch
hint: Use 'git am --show-current-patch' to see the failed patch
When you have resolved this problem, run "git am --continue".
If you prefer to skip this patch, run "git am --skip" instead.
To restore the original branch and stop patching, run "git am --abort".
  Something did not apply cleanly to Travertine-Proxy.
  Please review above details and finish the apply then
  save the changes with rebuildPatches.sh
```
4. Fix conflicts 
5. `git am --continue`
6. rebuild patches