### PR TITLE
Updated CONTRIBUTING and README to reflect the current status of FlameCord

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,33 +1,33 @@
-Contributing to Travertine
+Contributing to FlameCord
 ==========================
 WaterfallMC has a very lenient policy towards PRs, but would prefer that you try and adhere to the following guidelines.
 
 ## Understanding Patches
-Patches to Travertine are very simple, but center around the directory 'Travertine-Proxy'
+Patches to FlameCord are very simple, but center around the directory 'Travertine-Proxy'
 
 Assuming you already have forked the repository:
 
 1. Pull the latest changes from the main repository
-2. Type `./travertine p` in git bash to apply the changes from upstream
+2. Type `./flamecord p` in git bash to apply the changes from upstream
 3. cd into `Travertine-Proxy` for proxy changes
 
 This directory is not a git repository in the traditional sense:
 
 - Every single commit in Travertine-Proxy is a patch. 
-- 'origin/master' points to a directory similar to Travertine-Proxy but for Travertine
-- Typing `git status` should show that we are 10 or 11 commits ahead of master, meaning we have 10 or 11 patches that Travertine, Waterfall, and Bungeecord don't
+- 'origin/master' points to a directory similar to Travertine-Proxy but for FlameCord
+- Typing `git status` should show that we are 10 or 11 commits ahead of master, meaning we have 10 or 11 patches that FlameCord, Travertine, Waterfall, and Bungeecord don't
   - If it says something like `212 commits ahead, 207 commits behind`, then type `git fetch` to update Travertine
 
 ## Adding Patches
-Adding patches to Travertine is very simple:
+Adding patches to FlameCord is very simple:
 
 1. Modify `Travertine-Proxy` with the appropriate changes
 2. Type `git add .` to add your changes
 3. Run `git commit` with the desired patch message
-4. Run `./travertine rb` in the main directory to convert your commit into a new patch
+4. Run `./flamecord rb` in the main directory to convert your commit into a new patch
 5. PR your patches back to this repository
 
-Your commit will be converted into a patch that you can then PR into Travertine
+Your commit will be converted into a patch that you can then PR into FlameCord
 
 ## Modifying Patches
 Modifying previous patches is a bit more complex:
@@ -47,7 +47,7 @@ This method works by temporarily resetting HEAD to the desired commit to edit us
   - **MAKE SURE TO ADD `--amend`** or else a new patch will be created.
   - You can also modify the commit message here.
 7. Type `git rebase --continue` to finish rebasing.
-8. Type `./travertine rb` in the main directory.
+8. Type `./flamecord rb` in the main directory.
   - This will modify the appropriate patches based on your commits.
 9. PR your modifications back to this project.
 
@@ -58,27 +58,27 @@ If you are simply editing a more recent commit or your change is small, simply m
 2. Make a temporary commit. You don't need to make a message for this.
 3. Type `git rebase -i upstream/upstream`, move (cut) your temporary commit and move it under the line of the patch you wish to modify.
 4. Change the `pick` with `f` (fixup) or `s` (squash) if you need to edit the commit message 
-5. Type `./travertine rb` in the main directory.
+5. Type `./flamecord rb` in the main directory.
   - This will modify the appropriate patches based on your commits.
 6. PR your modifications to github
 
 
 ## PR Policy
-We'll accept changes that make sense. You should be able to justify their existence, along with any maintenance costs that come with them. Remember, these changes will affect everyone who runs Travertine, not just you and your server.
+We'll accept changes that make sense. You should be able to justify their existence, along with any maintenance costs that come with them. Remember, these changes will affect everyone who runs FlameCord, not just you and your server.
 While we will fix minor formatting issues, you should stick to the guide below when making and submitting changes.
 
 ## Formatting
-All modifications to non-Travertine files should be marked
-- Multi line changes start with `// Travertine start` and end with `// Travertine end`
-- You can put a messages with a change if it isn't obvious, like this: `// Travertine start - reason
+All modifications to non-FlameCord files should be marked
+- Multi line changes start with `// FlameCord start` and end with `// FlameCord end`
+- You can put a messages with a change if it isn't obvious, like this: `// FlameCord start - reason
   - Should generally be about the reason the change was made, what it was before, or what the change is
-  - Multi-line messages should start with `// Travertine start` and use `/* Multi line message here */` for the message itself
-- Single line changes should have `// Travertine` or `// Travertine - reason`
+  - Multi-line messages should start with `// FlameCord start` and use `/* Multi line message here */` for the message itself
+- Single line changes should have `// FlameCord` or `// FlameCord - reason`
 - For example:
 ````java
-return getConfig().getNotStupid(); // Travertine - was return getConfig().getStupid();
+return getConfig().getNotStupid(); // FlameCord - was return getConfig().getStupid();
 
-// Travertine start
+// FlameCord start
 // con.disconnect( bungee.getTranslation( "lost_connection" ) );
 ServerInfo def = con.updateAndGetNextServer( server.getInfo() );
 ServerKickEvent event = bungee.getPluginManager().callEvent( new ServerKickEvent( con, server.getInfo(), TextComponent.fromLegacyText( bungee.getTranslation( "lost_connection" ) ), def, ServerKickEvent.State.CONNECTED, ServerKickEvent.Cause.LOST_CONNECTION ) );
@@ -91,7 +91,7 @@ else
 {
     con.disconnect0( event.getKickReasonComponent() );
 }
-// Travertine end
+// FlameCord end
 ````
 - We generally follow usual java style, or what is programmed into most IDEs and formatters by default
   - This is also known as oracle style

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ FlameCord is a patch for Travertine to fix possible exploits and add useful func
 
 FlameCord is compiled like Travertine does; Please follow the CONTRIBUTING.md file. If you need help you can always contact us on Discord.
 
+To compile FlameCord you need the same requirements as Travertine, and run the command `./flamecord b` to get the corresponding jar.
+
 <a href="https://discord.gg/gF36AT3"><img src="https://discord.com/assets/4ff060e44afc171e9622fbe589c2c09e.png" width=10% height=10%><img/><a/> <a href="https://www.mc-market.org/resources/13492/"><img src="https://www.mc-market.org/styles/mcmarketv2/xenforo/logo.png" width=10% height=10%><img/><a/>
 
 Travertine [![Build Status](https://papermc.io/ci/job/Travertine/badge/icon)](https://papermc.io/ci/job/Travertine/)


### PR DESCRIPTION
To compile FlameCord it is required to use "./flamecord" commands instead of "./travertine" as it should be indicated in CONTRIBUTING.md and README.md. Therefore I have updated the files, showing how the commands currently are and how the comments should be.
A patch should also be created to change the name of the final file when using "./flamecord b" in the near future to avoid confusion. Currently it gives "Travertine.jar" instead of "FlameCord.jar" as shown in Actions.