### PR TITLE
Minor fixes and enhancements to README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 Contributing to FlameCord
 ==========================
-WaterfallMC has a very lenient policy towards PRs, but would prefer that you try and adhere to the following guidelines.
+FlameCord follows the parameters of the WaterfallMC project when making a Pull Request. WaterfallMC has a very lenient policy towards PRs, but would prefer that you try and adhere to the following guidelines.
 
 ## Understanding Patches
 Patches to FlameCord are very simple, but center around the directory 'FlameCord-Proxy'
@@ -14,8 +14,8 @@ Assuming you already have forked the repository:
 This directory is not a git repository in the traditional sense:
 
 - Every single commit in FlameCord-Proxy is a patch. 
-- 'origin/master' points to a directory similar to FlameCord-Proxy but for FlameCord
-- Typing `git status` should show that we are 10 or 11 commits ahead of master, meaning we have 10 or 11 patches that FlameCord, FlameCord, Waterfall, and Bungeecord don't
+- 'origin/master' points to a directory similar to Waterfall-Proxy but for FlameCord
+- Typing `git status` should show that we are 10 or 11 commits ahead of master, meaning we have 10 or 11 patches that FlameCord, Waterfall, and Bungeecord don't
   - If it says something like `212 commits ahead, 207 commits behind`, then type `git fetch` to update FlameCord
 
 ## Adding Patches
@@ -38,7 +38,6 @@ This method works by temporarily resetting HEAD to the desired commit to edit us
 1. If you have changes you are working on type `git stash` to store them for later.
   - Later you can type `git stash pop` to get them back.
 2. Type `git rebase -i upstream/upstream`
-  - It should show something like [this](https://gist.github.com/Zbob750/e6bb220d3b734933c320).
 3. Replace `pick` with `edit` for the commit/patch you want to modify, and "save" the changes.
   - Only do this for one commit at a time.
 4. Make the changes you want to make to the patch.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ FlameCord is compiled like Waterfall does; Please follow the [CONTRIBUTING.md](h
 
 <a href="https://discord.gg/gF36AT3"><img src="https://discord.com/assets/4ff060e44afc171e9622fbe589c2c09e.png" width=10% height=10%><img/><a/> <a href="https://www.mc-market.org/resources/13492/"><img src="https://www.mc-market.org/styles/mcmarketv2/xenforo/logo.png" width=10% height=10%><img/><a/>
 
+## Features
+
 Waterfall focuses on three main areas:
 
 * **Stability**: Waterfall aims to be stable. We will achieve this through making the code base testable and discouraging practices that lead to proxy lag.
@@ -19,7 +21,7 @@ FlameCord being a fork of Waterfall, has all its features, and some of its own, 
 
 ## Why fork Waterfall?
 
-Waterfall was forked because of the fact that Waterfall intends to only support protocol versions supported by upstream BungeeCord. 
+Waterfall was forked out of a desire for greater protection to be afforded to a Bungeecord-based proxy, which Waterfall currently cannot offer.
 
 FlameCord will track upstream Waterfall and merge changes as needed.
 
@@ -31,7 +33,7 @@ FlameCord requires **Java 8** or above.
 
 ## How To (Compiling from source)
 
-To compile FlameCord, you need JDK8, git, bash, maven, and an internet connection.
+To compile FlameCord, you need JDK8 or above, git, bash, maven, and an internet connection.
 
 Clone this repo, run `./flamecord b` from *bash*, get jar from `FlameCord-Proxy/bootstrap/target`
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,11 @@
 FlameCord
 =======
 
-FlameCord is a patch for FlameCord to fix possible exploits and add useful functionalities.
+FlameCord is a patch for Waterfall to fix possible exploits and add useful functionalities. Waterfall is a fork of the well-known [BungeeCord](https://github.com/SpigotMC/BungeeCord) server teleportation suite.
 
-FlameCord is compiled like FlameCord does; Please follow the CONTRIBUTING.md file. If you need help you can always contact us on Discord.
-
-To compile FlameCord you need the same requirements as FlameCord, and run the command `./flamecord b` to get the corresponding jar.
+FlameCord is compiled like Waterfall does; Please follow the [CONTRIBUTING.md](https://github.com/2lstudios-mc/FlameCord/blob/master/CONTRIBUTING.md) file. If you need help you can always contact us on Discord.
 
 <a href="https://discord.gg/gF36AT3"><img src="https://discord.com/assets/4ff060e44afc171e9622fbe589c2c09e.png" width=10% height=10%><img/><a/> <a href="https://www.mc-market.org/resources/13492/"><img src="https://www.mc-market.org/styles/mcmarketv2/xenforo/logo.png" width=10% height=10%><img/><a/>
-
-FlameCord
-=======
-
-FlameCord is Waterfall with additional protocols. Waterfall is a fork of the well-known [BungeeCord](https://github.com/SpigotMC/BungeeCord) server teleportation suite.
 
 Waterfall focuses on three main areas:
 
@@ -20,21 +13,19 @@ Waterfall focuses on three main areas:
 * **Features**: Waterfall aims to include more features than canonical BungeeCord.
 * **Scalability**: Waterfall should be able to handle a large number of concurrent players, given a reasonably modern CPU, memory, and good network connection.
 
-FlameCord focuses on one main area:
+FlameCord being a fork of Waterfall, has all its features, and some of its own, such as:
 
-* **Additional Client Version Support**: FlameCord aims to support client versions older then what is supported in upstream. This includes 1.7 support. Additionally FlameCord may release Snapshot and PRE Client support patches as time permits.
+* **Exploit Fixes**: FlameCord specializes in providing better server security by fixing major exploits, performance flaws and bugs that Bungeecord already has, and that have not yet been fixed in WaterfallMC.
 
 ## Why fork Waterfall?
 
-FlameCord has a goal of adding additional protocol versions.
-
-FlameCord was forked because of the fact that Waterfall intends to only support protocol versions supported by upstream BungeeCord. 
+Waterfall was forked because of the fact that Waterfall intends to only support protocol versions supported by upstream BungeeCord. 
 
 FlameCord will track upstream Waterfall and merge changes as needed.
 
 ## How to (Server Admins)
 
-Download a copy of FlameCord.jar from our homepage here: [FlameCord](https://papermc.io/downloads#FlameCord)
+You can support the development of FlameCord by purchasing it at [MC-Market](https://www.mc-market.org/resources/13492/). Or you can download it for free in the [releases tab](https://github.com/2lstudios-mc/FlameCord/releases). 
 
 FlameCord requires **Java 8** or above.
 
@@ -47,11 +38,4 @@ Clone this repo, run `./flamecord b` from *bash*, get jar from `FlameCord-Proxy/
 ## Join us
 
 * Feel free to open a PR! We accept contributions.
-* Join us on IRC (irc.spi.gt #paper, [webchat](http://irc.spi.gt/iris/?nick=&channels=paper)).
-* Visit our forums (https://papermc.io/forums).
-
-Special Thanks To
------------------
-![YourKit-Logo](https://yourkit.com/images/yklogo.png)
-
-[YourKit](https://yourkit.com/), makers of the outstanding Java profiler, supports open source projects of all kinds with their full-featured [Java](https://yourkit.com/features/) and [.NET](https://yourkit.com/dotnet/features/) application profilers. We thank them for granting FlameCord an OSS license so that we can make our software the best it can be.
+* Join to our [Discord Server](https://discord.gg/gF36AT3).

--- a/Waterfall-Proxy-Patches/0001-POM-Changes.patch
+++ b/Waterfall-Proxy-Patches/0001-POM-Changes.patch
@@ -476,7 +476,7 @@ index fd71cdbd..26e85fb8 100644
 -    <url>https://github.com/WaterfallMC/Waterfall</url>
 +    <name>FlameCord-Parent</name>
 +    <description>Parent project for all FlameCord modules.</description>
-+    <url>https://github.com/PaperMC/FlameCord</url>
++    <url>https://github.com/2lstudios-mc/FlameCord</url>
      <inceptionYear>2015</inceptionYear>
      <organization>
          <name>WaterfallMC</name>
@@ -487,14 +487,14 @@ index fd71cdbd..26e85fb8 100644
 -        <connection>scm:git:git@github.com:com:WaterfallMC/Waterfall.git</connection>
 -        <developerConnection>scm:git:git@github.com:WaterfallMC/Waterfall.git</developerConnection>
 -        <url>git@github.com:WaterfallMC/Waterfall.git</url>
-+        <connection>scm:git:git@github.com:com:PaperMC/FlameCord.git</connection>
-+        <developerConnection>scm:git:git@github.com:PaperMC/FlameCord.git</developerConnection>
-+        <url>git@github.com:PaperMC/FlameCord.git</url>
++        <connection>scm:git:git@github.com:com:2lstudios-mc/FlameCord.git</connection>
++        <developerConnection>scm:git:git@github.com:2lstudios-mc/FlameCord.git</developerConnection>
++        <url>git@github.com:2lstudios-mc/FlameCord.git</url>
      </scm>
      <issueManagement>
          <system>GitHub</system>
 -        <url>https://github.com/PaperMC/Waterfall/issues</url>
-+        <url>https://github.com/PaperMC/FlameCord/issues</url>
++        <url>https://github.com/2lstudios-mc/FlameCord/issues</url>
      </issueManagement>
  
      <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <name>FlameCord-Super</name>
     <description>Super project for FlameCord.</description>
-    <url>https://github.com/WaterfallMC/FlameCord</url>
+    <url>https://github.com/2lstudios-mc/FlameCord</url>
 
     <modules>
         <module>FlameCord-Proxy</module>


### PR DESCRIPTION
Now that FlameCord is based on Waterfall instead of Travertine, I fixed the existing bugs in the markdown files README.md, CONTRIBUTING.md and in patch 0001. Along with that, I improved the text of the files, based on what I think can better present the product.