### PR TITLE
Updated Upstream (Waterfall)

### DIFF
--- a/Waterfall-Proxy-Patches/0009-Close-connections-Don-t-flush-if-not-necessary.patch
+++ b/Waterfall-Proxy-Patches/0009-Close-connections-Don-t-flush-if-not-necessary.patch
@@ -1,11 +1,11 @@
-From fd1cdbfda00482440c45e74217c78f5b62b1be49 Mon Sep 17 00:00:00 2001
+From cf8b96298bc7e02d04b30aa1dca04968bda068d8 Mon Sep 17 00:00:00 2001
 From: foss-mc <69294560+foss-mc@users.noreply.github.com>
 Date: Wed, 16 Dec 2020 18:06:17 +0800
 Subject: [PATCH] Close connections & Don't flush if not necessary
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 49ba34db..6e148782 100644
+index 0647a774..37784acd 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 @@ -192,6 +192,13 @@ public class InitialHandler extends PacketHandler implements PendingConnection
@@ -56,7 +56,7 @@ index 49ba34db..6e148782 100644
      }
  
      @Override
-@@ -606,7 +624,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -600,7 +618,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      {
          if ( canSendKickMessage() )
          {
@@ -173,5 +173,5 @@ index 0c1ecfb8..b3bdfd05 100644
          }
  
 -- 
-2.31.1.windows.1
+2.32.0.windows.1
 

--- a/Waterfall-Proxy-Patches/0012-Change-state-to-encrypt-only-if-onlineMode-is-true.patch
+++ b/Waterfall-Proxy-Patches/0012-Change-state-to-encrypt-only-if-onlineMode-is-true.patch
@@ -1,14 +1,14 @@
-From c21daf0a4ba52c12de9e92b1eb815c893e93db4d Mon Sep 17 00:00:00 2001
+From bb419bd35b5e513be0ca20cda4c97bcaa23f0cd7 Mon Sep 17 00:00:00 2001
 From: foss-mc <69294560+foss-mc@users.noreply.github.com>
 Date: Wed, 16 Dec 2020 18:25:03 +0800
 Subject: [PATCH] Change state to encrypt only if onlineMode is true
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 6e148782..e23cf604 100644
+index 37784acd..1811084a 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -432,11 +432,12 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -426,11 +426,12 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                  if ( onlineMode )
                  {
                      unsafe().sendPacket( request = EncryptionUtil.encryptRequest() );
@@ -23,5 +23,5 @@ index 6e148782..e23cf604 100644
          };
  
 -- 
-2.31.1.windows.1
+2.32.0.windows.1
 

--- a/Waterfall-Proxy-Patches/0013-Don-t-allow-name-containing-dot.patch
+++ b/Waterfall-Proxy-Patches/0013-Don-t-allow-name-containing-dot.patch
@@ -1,14 +1,14 @@
-From c180aa80773a50794cef5bff389d663b876b49b3 Mon Sep 17 00:00:00 2001
+From 9754f77c4142bebe9425d493b6826503dd9060f9 Mon Sep 17 00:00:00 2001
 From: foss-mc <69294560+foss-mc@users.noreply.github.com>
 Date: Wed, 16 Dec 2020 18:25:51 +0800
 Subject: [PATCH] Don't allow name containing dot
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 9293739f..10b5aafb 100644
+index 1811084a..1925188f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -387,13 +387,16 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -387,7 +387,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          Preconditions.checkState( thisState == State.USERNAME, "Not expecting USERNAME" );
          this.loginRequest = loginRequest;
  
@@ -20,13 +20,6 @@ index 9293739f..10b5aafb 100644
          {
              disconnect( bungee.getTranslation( "name_invalid" ) );
              return;
-         }
- 
--        if ( getName().length() > 16 )
-+        if ( name.length() > 16 )
-         {
-             disconnect( bungee.getTranslation( "name_too_long" ) );
-             return;
 -- 
-2.31.1.windows.1
+2.32.0.windows.1
 

--- a/Waterfall-Proxy-Patches/0015-Allow-custom-uuids-even-if-onlineMode-is-true.patch
+++ b/Waterfall-Proxy-Patches/0015-Allow-custom-uuids-even-if-onlineMode-is-true.patch
@@ -1,14 +1,14 @@
-From 6b6dd8e0fc01d46fb928cbac548cc2ca1a0a7da1 Mon Sep 17 00:00:00 2001
+From ac987c138b977c2029dc845bbec5f9a1b70dd746 Mon Sep 17 00:00:00 2001
 From: foss-mc <69294560+foss-mc@users.noreply.github.com>
 Date: Wed, 16 Dec 2020 18:35:33 +0800
 Subject: [PATCH] Allow custom uuids even if onlineMode is true
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index b4067b1e..3120abdb 100644
+index 1925188f..554526a3 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -686,7 +686,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -680,7 +680,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      public void setUniqueId(UUID uuid)
      {
          Preconditions.checkState( thisState == State.USERNAME, "Can only set uuid while state is username" );
@@ -18,5 +18,5 @@ index b4067b1e..3120abdb 100644
      }
  
 -- 
-2.31.1.windows.1
+2.32.0.windows.1
 

--- a/Waterfall-Proxy-Patches/0016-Finish-early-to-avoid-multiple-incoming-packets.patch
+++ b/Waterfall-Proxy-Patches/0016-Finish-early-to-avoid-multiple-incoming-packets.patch
@@ -1,14 +1,14 @@
-From a497afed2aec0b47499e6d4f9cadedab6a2512f6 Mon Sep 17 00:00:00 2001
+From f8d0abde43d1fa6abc45631b372e5a71d1af2f48 Mon Sep 17 00:00:00 2001
 From: foss-mc <69294560+foss-mc@users.noreply.github.com>
 Date: Wed, 16 Dec 2020 18:36:08 +0800
 Subject: [PATCH] Finish early to avoid multiple incoming packets
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 3120abdb..4a17a117 100644
+index 554526a3..e643d8a7 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -453,6 +453,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -447,6 +447,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      {
          Preconditions.checkState( thisState == State.ENCRYPT, "Not expecting ENCRYPT" );
  
@@ -17,7 +17,7 @@ index 3120abdb..4a17a117 100644
          SecretKey sharedKey = EncryptionUtil.getSecret( encryptResponse, request );
          // Waterfall start
          if (sharedKey instanceof SecretKeySpec) {
-@@ -512,6 +514,9 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -506,6 +508,9 @@ public class InitialHandler extends PacketHandler implements PendingConnection
  
      private void finish()
      {
@@ -27,7 +27,7 @@ index 3120abdb..4a17a117 100644
          if ( isOnlineMode() )
          {
              // Check for multiple connections
-@@ -593,8 +598,6 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -587,8 +592,6 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                              }
  
                              userCon.connect( server, null, true, ServerConnectEvent.Reason.JOIN_PROXY );
@@ -37,5 +37,5 @@ index 3120abdb..4a17a117 100644
                      }
                  } );
 -- 
-2.31.1.windows.1
+2.32.0.windows.1
 

--- a/Waterfall-Proxy-Patches/0017-Change-IllegalStateException-to-QuietException-and-e.patch
+++ b/Waterfall-Proxy-Patches/0017-Change-IllegalStateException-to-QuietException-and-e.patch
@@ -1,4 +1,4 @@
-From 68f77c174634d73fbce5ddee67d9168277447333 Mon Sep 17 00:00:00 2001
+From 8b3e6f968ad9a19466653d9a08b31da13567b6d2 Mon Sep 17 00:00:00 2001
 From: foss-mc <69294560+foss-mc@users.noreply.github.com>
 Date: Wed, 16 Dec 2020 18:40:55 +0800
 Subject: [PATCH] Change IllegalStateException to QuietException and explain
@@ -6,10 +6,10 @@ Subject: [PATCH] Change IllegalStateException to QuietException and explain
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index 01075a85..fb065ccd 100644
+index fc98b4b1..db79b58a 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -309,7 +309,8 @@ public final class UserConnection implements ProxiedPlayer
+@@ -310,7 +310,8 @@ public final class UserConnection implements ProxiedPlayer
  
              if ( getServer() == null && !ch.isClosing() )
              {
@@ -20,5 +20,5 @@ index 01075a85..fb065ccd 100644
              return;
          }
 -- 
-2.31.1.windows.1
+2.32.0.windows.1
 

--- a/Waterfall-Proxy-Patches/0018-Don-t-declare-uuid-unless-it-s-null.patch
+++ b/Waterfall-Proxy-Patches/0018-Don-t-declare-uuid-unless-it-s-null.patch
@@ -1,14 +1,14 @@
-From d8d2c3450c09ebcc32c821e99b0fa4c7559a18a9 Mon Sep 17 00:00:00 2001
+From ae64b8938eadb7ee4b0c68572b4e270530603ad9 Mon Sep 17 00:00:00 2001
 From: foss-mc <69294560+foss-mc@users.noreply.github.com>
 Date: Wed, 16 Dec 2020 18:43:17 +0800
 Subject: [PATCH] Don't declare uuid unless it's null
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 4a17a117..95a6f40c 100644
+index e643d8a7..dc5b64b7 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -496,7 +496,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -490,7 +490,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                      {
                          loginProfile = obj;
                          name = obj.getName();
@@ -21,5 +21,5 @@ index 4a17a117..95a6f40c 100644
                          return;
                      }
 -- 
-2.31.1.windows.1
+2.32.0.windows.1
 

--- a/Waterfall-Proxy-Patches/0019-FlameCord-General-Patch.patch
+++ b/Waterfall-Proxy-Patches/0019-FlameCord-General-Patch.patch
@@ -1,4 +1,4 @@
-From 91af7ea587264e4af28fecb81b12163fe8a7f75e Mon Sep 17 00:00:00 2001
+From 1f6d89b080f89d2a235554957815deb3047dab05 Mon Sep 17 00:00:00 2001
 From: Juan Cruz Linsalata <LinsaFTW@users.noreply.github.com>
 Date: Mon, 12 Oct 2020 15:40:53 -0300
 Subject: [PATCH] FlameCord General Patch
@@ -191,7 +191,7 @@ index 00000000..a323598e
 +    }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 3e7bd97b..46f180a0 100644
+index 778fe4a1..9c45f305 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -9,6 +9,9 @@ import com.google.common.collect.Sets;
@@ -285,10 +285,10 @@ index f5e09292..3e3e42a2 100644
      }
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index fb065ccd..3d18dbf9 100644
+index db79b58a..a847c049 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -35,6 +35,7 @@ import net.md_5.bungee.api.SkinConfiguration;
+@@ -36,6 +36,7 @@ import net.md_5.bungee.api.SkinConfiguration;
  import net.md_5.bungee.api.Title;
  import net.md_5.bungee.api.chat.BaseComponent;
  import net.md_5.bungee.api.chat.TextComponent;
@@ -296,7 +296,7 @@ index fb065ccd..3d18dbf9 100644
  import net.md_5.bungee.api.config.ServerInfo;
  import net.md_5.bungee.api.connection.ProxiedPlayer;
  import net.md_5.bungee.api.event.PermissionCheckEvent;
-@@ -65,6 +66,7 @@ import net.md_5.bungee.tab.ServerUnique;
+@@ -66,6 +67,7 @@ import net.md_5.bungee.tab.ServerUnique;
  import net.md_5.bungee.tab.TabList;
  import net.md_5.bungee.util.CaseInsensitiveSet;
  import net.md_5.bungee.util.ChatComponentTransformer;
@@ -304,7 +304,7 @@ index fb065ccd..3d18dbf9 100644
  
  @RequiredArgsConstructor
  public final class UserConnection implements ProxiedPlayer
-@@ -389,9 +391,11 @@ public final class UserConnection implements ProxiedPlayer
+@@ -390,9 +392,11 @@ public final class UserConnection implements ProxiedPlayer
                  .option( ChannelOption.CONNECT_TIMEOUT_MILLIS, request.getConnectTimeout() )
                  .remoteAddress( target.getAddress() );
          // Windows is bugged, multi homed users will just have to live with random connecting IPs
@@ -319,7 +319,7 @@ index fb065ccd..3d18dbf9 100644
          b.connect().addListener( listener );
      }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index aa952717..a1ec1bff 100644
+index dc5b64b7..e88ec72a 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 @@ -14,6 +14,8 @@ import java.util.logging.Level;
@@ -379,5 +379,5 @@ index 654203ab..a840bc70 100644
  import io.netty.buffer.PooledByteBufAllocator;
  import io.netty.channel.Channel;
 -- 
-2.31.1.windows.1
+2.32.0.windows.1
 


### PR DESCRIPTION
Upstream has released updates that appears to apply and compile correctly.
This update has not been tested by 2LStudios and as with ANY update, please do your own testing

Waterfall Changes:
a5c78a9 (Maybe) Fix javadoc search
eb920b8 Updated Upstream (BungeeCord)
8e9b90a fix compile-native not working on linux
ee819df Updated Upstream (BungeeCord)
66601f7 [ci skip] link to javadocs page instead of attempting direct