### PR TITLE
Updated Upstream (Waterfall)

### DIFF
--- a/Waterfall-Proxy-Patches/0003-Rename-references-from-Waterfall-to-FlameCord.patch
+++ b/Waterfall-Proxy-Patches/0003-Rename-references-from-Waterfall-to-FlameCord.patch
@@ -1,11 +1,11 @@
-From a5f023bb3c21941eaf45f1c8946b719d0752590e Mon Sep 17 00:00:00 2001
+From 97946438e45cb5480c3924d5c340cecd1f1a354f Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Mon, 6 Jun 2016 13:47:46 -0600
 Subject: [PATCH] Rename references from Waterfall to FlameCord
 
 
 diff --git a/bootstrap/src/main/java/net/md_5/bungee/Bootstrap.java b/bootstrap/src/main/java/net/md_5/bungee/Bootstrap.java
-index a4516ed96..1f63a2c27 100644
+index a4516ed9..9838f5c5 100644
 --- a/bootstrap/src/main/java/net/md_5/bungee/Bootstrap.java
 +++ b/bootstrap/src/main/java/net/md_5/bungee/Bootstrap.java
 @@ -7,7 +7,7 @@ public class Bootstrap
@@ -18,7 +18,7 @@ index a4516ed96..1f63a2c27 100644
              return;
          }
 diff --git a/log/src/main/java/net/md_5/bungee/log/LogDispatcher.java b/log/src/main/java/net/md_5/bungee/log/LogDispatcher.java
-index d703d6d24..d8dcdc1e3 100644
+index d703d6d2..49dce84b 100644
 --- a/log/src/main/java/net/md_5/bungee/log/LogDispatcher.java
 +++ b/log/src/main/java/net/md_5/bungee/log/LogDispatcher.java
 @@ -12,7 +12,7 @@ public class LogDispatcher extends Thread
@@ -31,7 +31,7 @@ index d703d6d24..d8dcdc1e3 100644
      }
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index c09f5b4c3..97de4271c 100644
+index 07d74c67..a4b58d9c 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -188,7 +188,7 @@ public class BungeeCord extends ProxyServer
@@ -53,10 +53,10 @@ index c09f5b4c3..97de4271c 100644
  
      @Override
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java b/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
-index 356805285..1c2628d31 100644
+index 0db3d76a..25da0a65 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
-@@ -76,7 +76,7 @@ public class BungeeCordLauncher
+@@ -63,7 +63,7 @@ public class BungeeCordLauncher
  
          BungeeCord bungee = new BungeeCord();
          ProxyServer.setInstance( bungee );
@@ -66,7 +66,7 @@ index 356805285..1c2628d31 100644
  
          if ( !options.has( "noconsole" ) )
 diff --git a/proxy/src/main/java/net/md_5/bungee/command/CommandBungee.java b/proxy/src/main/java/net/md_5/bungee/command/CommandBungee.java
-index b26035cf9..4e2c6129c 100644
+index b26035cf..820f7b03 100644
 --- a/proxy/src/main/java/net/md_5/bungee/command/CommandBungee.java
 +++ b/proxy/src/main/java/net/md_5/bungee/command/CommandBungee.java
 @@ -16,6 +16,6 @@ public class CommandBungee extends Command
@@ -78,7 +78,7 @@ index b26035cf9..4e2c6129c 100644
      }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/command/CommandReload.java b/proxy/src/main/java/net/md_5/bungee/command/CommandReload.java
-index 720d0c3b5..dca7601b0 100644
+index 720d0c3b..5ab4db18 100644
 --- a/proxy/src/main/java/net/md_5/bungee/command/CommandReload.java
 +++ b/proxy/src/main/java/net/md_5/bungee/command/CommandReload.java
 @@ -23,7 +23,7 @@ public class CommandReload extends Command
@@ -92,7 +92,7 @@ index 720d0c3b5..dca7601b0 100644
      }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
-index 65121ba24..d4fad294c 100644
+index 0644b8cd..9c11ac57 100644
 --- a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
 +++ b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
 @@ -227,7 +227,7 @@ public class YamlConfig implements ConfigurationAdapter
@@ -105,5 +105,5 @@ index 65121ba24..d4fad294c 100644
              SocketAddress address = Util.getAddr( addr );
              ServerInfo info = ProxyServer.getInstance().constructServerInfo( name, address, motd, restricted );
 -- 
-2.31.1
+2.32.0.windows.1
 

--- a/Waterfall-Proxy-Patches/0007-Disable-update-checker-Use-bungee-name.patch
+++ b/Waterfall-Proxy-Patches/0007-Disable-update-checker-Use-bungee-name.patch
@@ -1,14 +1,14 @@
-From 930c3622edaa63c7538d225d809e84c55b6a14fb Mon Sep 17 00:00:00 2001
+From 6cc482b6a66e0085ff7eb4ad565592ec9dd0d285 Mon Sep 17 00:00:00 2001
 From: foss-mc <69294560+foss-mc@users.noreply.github.com>
 Date: Wed, 16 Dec 2020 18:00:49 +0800
 Subject: [PATCH] Disable update checker & Use bungee name
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java b/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
-index 713bbbef..96db5e5e 100644
+index 25da0a65..d4b612b3 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
-@@ -58,25 +58,12 @@ public class BungeeCordLauncher
+@@ -45,25 +45,12 @@ public class BungeeCordLauncher
              return;
          }
  
@@ -38,7 +38,7 @@ index 713bbbef..96db5e5e 100644
  
          if ( !options.has( "noconsole" ) )
 diff --git a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
-index d5b3e6f8..7994c1c1 100644
+index 9c11ac57..ae4c7ac2 100644
 --- a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
 +++ b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
 @@ -22,6 +22,7 @@ import java.util.Locale;
@@ -70,5 +70,5 @@ index d5b3e6f8..7994c1c1 100644
  
              int maxPlayers = get( "max_players", 1, val );
 -- 
-2.31.1.windows.1
+2.32.0.windows.1
 

--- a/Waterfall-Proxy-Patches/0020-FlameCord-module-system.patch
+++ b/Waterfall-Proxy-Patches/0020-FlameCord-module-system.patch
@@ -1,4 +1,4 @@
-From 9d1c11965e719870b3f8cd3c31cfeb4ca966cde0 Mon Sep 17 00:00:00 2001
+From 67799e8a980a77546059d9c362d9845fce792f22 Mon Sep 17 00:00:00 2001
 From: linsaftw <25271111+linsaftw@users.noreply.github.com>
 Date: Sat, 1 May 2021 14:17:48 -0300
 Subject: [PATCH] FlameCord module system
@@ -134,7 +134,7 @@ index 00000000..e82c4844
 +        }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 46f180a0..b1ac28a5 100644
+index a788559e..7681240b 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -12,6 +12,7 @@ import com.google.gson.GsonBuilder;
@@ -166,7 +166,7 @@ index 46f180a0..b1ac28a5 100644
  
          if ( config.isForgeSupport() )
          {
-@@ -825,4 +828,56 @@ public class BungeeCord extends ProxyServer
+@@ -830,4 +833,56 @@ public class BungeeCord extends ProxyServer
      {
          return new BungeeTitle();
      }
@@ -224,5 +224,5 @@ index 46f180a0..b1ac28a5 100644
 +    }
  }
 -- 
-2.31.1.windows.1
+2.32.0.windows.1
 


### PR DESCRIPTION
Upstream has released updates that appears to apply and compile correctly.
This update has not been tested by 2LStudios and as with ANY update, please do your own testing

Waterfall Changes:
f17de74 remove 4MB buffer size limit due to protocol changes
dc044fb Don't bother locking to fetch a v4 UUID from the offline UUIDs map