### PR TITLE
Updated workflow for Github Actions and fixed typo

### DIFF
--- a/.github/workflows/flamecord-build.yml
+++ b/.github/workflows/flamecord-build.yml
@@ -15,14 +15,14 @@ jobs:
     # latest version up to the moment.
     strategy:
       matrix:
-        java: [8, 11, 16]
+        java: [8, 11, 17]
 
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2
       
     - name: Setup JAVA ${{ matrix.java }}
-      uses: actions/setup-java@v2.1.0
+      uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java }}
         distribution: 'adopt'
@@ -30,7 +30,7 @@ jobs:
     
     # The corresponding dependencies are stored in the cache to speed up the test.
     - name: Cache Maven Packages
-      uses: actions/cache@v2.1.6
+      uses: actions/cache@v2
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -44,7 +44,7 @@ jobs:
       
     # An artifact is generated in a compressed file according to each JDK build version.
     - name: Upload FlameCord
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v2
       with:
         name: FlameCord-JDK${{ matrix.java }}
         path: FlameCord-Proxy/bootstrap/target/FlameCord.jar

--- a/.github/workflows/flamecord-pull-request.yml
+++ b/.github/workflows/flamecord-pull-request.yml
@@ -14,14 +14,14 @@ jobs:
     # latest version up to the moment.
     strategy:
       matrix:
-        java: [8, 11, 16]
+        java: [8, 11, 17]
 
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2
       
     - name: Setup JAVA ${{ matrix.java }}
-      uses: actions/setup-java@v2.1.0
+      uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java }}
         distribution: 'adopt'
@@ -29,7 +29,7 @@ jobs:
     
     # The corresponding dependencies are stored in the cache to speed up the test.
     - name: Cache Maven Packages
-      uses: actions/cache@v2.1.6
+      uses: actions/cache@v2
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -43,7 +43,7 @@ jobs:
       
     # An artifact is generated in a compressed file according to each JDK build version.
     - name: Upload FlameCord
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v2
       with:
         name: FlameCord-JDK${{ matrix.java }}
         path: FlameCord-Proxy/bootstrap/target/FlameCord.jar

--- a/scripts/upstreamCommit.sh
+++ b/scripts/upstreamCommit.sh
@@ -15,7 +15,7 @@ if [ ! -z "$waterfall" ]; then
     logsuffix="$logsuffix\n\nWaterfall Changes:\n$waterfall"
     if [ -z "$updated" ]; then updated="Waterfall"; else updated="$updated/Waterfall"; fi
 fi
-disclaimer="Upstream has released updates that appears to apply and compile correctly.\nThis update has not been tested by 2LStudios and as with ANY update, please do your own testing"
+disclaimer="Upstream has released updates that appear to apply and compile correctly.\nThis update has not been tested by 2LStudios and as with ANY update, please do your own testing"
 
 if [ ! -z "$1" ]; then
     disclaimer="$@"


### PR DESCRIPTION
Minecraft 1.18 requires Java 17, so I think it would be better to use Java 17 to build and test FlameCord. I also changed the versions of the actions to `@v2` because this will make sure that Github uses the latest 2.x version of these actions. Also fixed a small typo.