### PR TITLE
Fix build, because the brand isn't correct.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <url>https://github.com/2lstudios-mc/FlameCord</url>
 
     <modules>
-        <module>Waterfall-Proxy</module>
+        <module>FlameCord-Proxy</module>
     </modules>
 
     <build>


### PR DESCRIPTION
I was trying to build FlameCord and i saw that issue, it's solved by editing the brand from Waterfall to FlameCord like the module name.