### PR TITLE
Fix build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <url>https://github.com/2lstudios-mc/FlameCord</url>
 
     <modules>
-        <module>Waterfall-Proxy</module>
+        <module>FlameCord-Proxy</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Fix FlameCord build, due the proxy module was not rigthly named.