### PR TITLE
Fix for player info removal packet disconnection.

### DIFF
--- a/Waterfall-Proxy-Patches/0037-Fix-for-player-info-removal-packets-disconnecting-pl.patch
+++ b/Waterfall-Proxy-Patches/0037-Fix-for-player-info-removal-packets-disconnecting-pl.patch
@@ -1,0 +1,22 @@
+From ac78cff627cbb1f0cb287465a27ebf38accce8c2 Mon Sep 17 00:00:00 2001
+From: Fabelz <fabelzdev@gmail.com>
+Date: Tue, 20 Dec 2022 20:44:07 +1100
+Subject: [PATCH] Fix for player info removal packets disconnecting players on
+ server switching.
+
+
+diff --git a/proxy/src/main/java/net/md_5/bungee/tab/ServerUnique.java b/proxy/src/main/java/net/md_5/bungee/tab/ServerUnique.java
+index 118c78f4..df6a4b12 100644
+--- a/proxy/src/main/java/net/md_5/bungee/tab/ServerUnique.java
++++ b/proxy/src/main/java/net/md_5/bungee/tab/ServerUnique.java
+@@ -105,6 +105,7 @@ public class ServerUnique extends TabList
+                 PlayerListItem.Item item = items[i++] = new PlayerListItem.Item();
+                 item.setUsername( username );
+                 item.setDisplayName( username );
++                item.setPing( 0 );
+             }
+             // FlameCord end - 1.7.x support
+ 
+-- 
+2.35.0.windows.1
+


### PR DESCRIPTION
When players switch between two servers (whilst using a 1.7-based client), the server will disconnect them due to the legacy supporting code not specifying the player's ping on the player list item's creation, and due to the ping field being an Integer instead of an int.

This patch rectifies this by setting their ping on the list item's creation to 0, as it doesn't matter regardless as the items are being used to garbage collect players from the old server's player list on server switch.

Fixes the below client-sided exception (attached for bookkeeping purposes):
![image](https://user-images.githubusercontent.com/15955937/208637388-4fee22a8-f85c-46f1-b9c8-0107883fc490.png)
