### PR TITLE
Add SQLite driver

### DIFF
--- a/Waterfall-Proxy-Patches/0036-Added-SQLite-driver.patch
+++ b/Waterfall-Proxy-Patches/0036-Added-SQLite-driver.patch
@@ -1,0 +1,26 @@
+From f75f1e4ecb988c5615b7a72d4d171107bf08987e Mon Sep 17 00:00:00 2001
+From: Angelillo15 <angelrizosrubios@gmail.com>
+Date: Fri, 23 Dec 2022 19:45:44 +0100
+Subject: [PATCH] Added SQLite driver
+
+
+diff --git a/proxy/pom.xml b/proxy/pom.xml
+index 10fe411d..d0a4603e 100644
+--- a/proxy/pom.xml
++++ b/proxy/pom.xml
+@@ -201,6 +201,12 @@
+             <version>${project.version}</version>
+             <scope>compile</scope>
+         </dependency>
++        <dependency>
++            <groupId>org.xerial</groupId>
++            <artifactId>sqlite-jdbc</artifactId>
++            <version>3.40.0.0</version>
++            <scope>runtime</scope>
++        </dependency>
+         <!-- FlameCord end -->
+     </dependencies>
+ 
+-- 
+2.38.0.windows.1
+


### PR DESCRIPTION
Many plugins needs the SQLite driver, for this reason I think it should be included instead that all the plugins shade the driver