### PR TITLE
fix: fixed shields (badges) redirect link on click

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,8 +60,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+reported to the community leaders responsible for enforcement at our [Discord server](https://discord.gg/gF36AT3).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # FlameCord
 
-![Download](https://img.shields.io/badge/Download-%244.99-blue?style=flat-square) ![Discord](https://img.shields.io/discord/442079515498381312?style=flat-square&color=%237289da&label=Discord&logo=discord&logoColor=%237289da) ![GitHub](https://img.shields.io/github/license/2lstudios-mc/flamecord?style=flat-square)
+<a href="https://builtbybit.com/resources/flamecord-mitigate-bots-exploits.13492/" alt="Download">
+    <img src="https://img.shields.io/badge/Download-%244.99-blue?style=flat-square" />
+</a>
+<a href="https://discord.com/invite/gF36AT3" alt="Discord">
+    <img src="https://img.shields.io/discord/442079515498381312?style=flat-square&color=%237289da&label=Discord&logo=discord&logoColor=%237289da" />
+</a>
+<a href="https://github.com/sammwyy/FlameCord/blob/master/LICENSE.txt" alt="License">
+    <img src="https://img.shields.io/github/license/2lstudios-mc/flamecord?style=flat-square" />
+</a>
 
 FlameCord is a Waterfall fork or modification that adds antibot features, exploit prevention systems, performance improvements, removal of unused features, library updates and application layer ddos mitigation.
 
@@ -58,4 +66,4 @@ FlameCord is compiled like Waterfall does; Please follow the [CONTRIBUTING.md](h
 ## 📝 License
 
 Copyright © 2018-2023 [2LStudios](https://github.com/2lstudios-mc).  
-This project is [MIT License](LICENSE.txt) licensed.  
+This project is [MIT License](LICENSE.txt) licensed.


### PR DESCRIPTION
Sorry, in my previous PR the badge links didn't work.

- Fixed Discord link.
- Fixed BBB link.
- Fixed license link.